### PR TITLE
Fix signed message header to match Dogecoin reference client

### DIFF
--- a/core/src/main/java/com/google/dogecoin/core/Utils.java
+++ b/core/src/main/java/com/google/dogecoin/core/Utils.java
@@ -54,7 +54,7 @@ public class Utils {
     }
 
     /** The string that prefixes all text messages signed using Bitcoin keys. */
-    public static final String BITCOIN_SIGNED_MESSAGE_HEADER = "Bitcoin Signed Message:\n";
+    public static final String BITCOIN_SIGNED_MESSAGE_HEADER = "Dogecoin Signed Message:\n";
     public static final byte[] BITCOIN_SIGNED_MESSAGE_HEADER_BYTES = BITCOIN_SIGNED_MESSAGE_HEADER.getBytes(Charsets.UTF_8);
 
     // TODO: Replace this nanocoins business with something better.


### PR DESCRIPTION
possible fix for [/langerhans/multidoge/#20](https://github.com/langerhans/multidoge/issues/20). I just touched that code in another client when I saw that issue, so I though this is probably the cause. Untested.
