### PR TITLE
fix package

### DIFF
--- a/core/src/main/java/com/dogecoin/dogecoinj/kits/WalletAppKit.java
+++ b/core/src/main/java/com/dogecoin/dogecoinj/kits/WalletAppKit.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.bitcoinj.kits;
+package com.dogecoin.dogecoinj.kits;
 
 import com.google.common.collect.*;
 import com.google.common.util.concurrent.*;


### PR DESCRIPTION
It seems that WalletAppKit class is in the wrong package. Breaks the build (examples)