### PR TITLE
Fix opReturnCount logic

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -4142,8 +4142,8 @@ public class Wallet extends BaseTaggableObject
             if (req.ensureMinRequiredFee && !req.emptyWallet) { // Min fee checking is handled later for emptyWallet.
                 int opReturnCount = 0;
                 for (TransactionOutput output : req.tx.getOutputs()) {
-                    if (output.isDust())
-                        //throw new DustySendRequested();
+                    // if (output.isDust())
+                    //     throw new DustySendRequested();
                     if (ScriptPattern.isOpReturn(output.getScriptPubKey()))
                         ++opReturnCount;
                 }


### PR DESCRIPTION
This PR is a bit out of the blue, but I was interested in how you modified bitcoinj to work for dogecoin when I noticed what may have been a typo.

When commenting out this statement, you may have unintentionally affected the other if statement which follows.

```java
for (TransactionOutput output : req.tx.getOutputs()) {
    if (output.isDust())
        //throw new DustySendRequested();
    if (ScriptPattern.isOpReturn(output.getScriptPubKey()))
        ++opReturnCount;
}

// is equivalent to

for (TransactionOutput output : req.tx.getOutputs()) {
    if (output.isDust())
        if (ScriptPattern.isOpReturn(output.getScriptPubKey()))
            ++opReturnCount;
}
```

Now the `++opReturnCount` statement is conditional on both the `isDust()` check and the `isOpReturn()` check.

Demonstration
![The second print statement doesn't run even if the condition is true](https://user-images.githubusercontent.com/4038174/111890077-27e50e80-89de-11eb-9e1e-0b62c3fc0455.png)

If it was intentional sorry for wasting your time 😅 